### PR TITLE
Checking mergeability of pull requests

### DIFF
--- a/.github/workflows/mpv.yml
+++ b/.github/workflows/mpv.yml
@@ -1,5 +1,5 @@
 name: MPV
-run-name: "${{ inputs.run_name != '' && format('{0} ({1})', inputs.run_name, inputs.compiler) || format('{0} ({1})', github.workflow, inputs.compiler) }}"
+run-name: "${{ inputs.run_name != '' && format('{0} ({1})', inputs.run_name, inputs.compiler) || inputs.prs != '' && format('{0}[{2}] ({1})', github.workflow, inputs.compiler, inputs.prs) || format('{0} ({1})', github.workflow, inputs.compiler) }}"
 
 on: 
   workflow_dispatch:
@@ -91,7 +91,15 @@ jobs:
             core.setOutput("matrix",JSON.stringify(matrix));
 
             const fs = require('fs/promises');
-            let prs = "${{ inputs.prs }}".split(',');
+            const timer = ms => new Promise(res => setTimeout(res, ms));
+            const checkingMergeability = async(o)=>{
+              while (true) {
+                const res = await github.rest.pulls.get(o);
+                if (res.data.merged || res.data.mergeable != null) return res;
+                await timer(300);
+              }
+            };
+            let prs = "${{ inputs.prs }}".split(',').map(e=>e.trim());
             let i = 1;
             let patch_note = "";
 
@@ -103,7 +111,7 @@ jobs:
               }
               
               try {
-                const res = await github.rest.pulls.get({
+                const res = await checkingMergeability({
                   owner: "mpv-player",
                   repo: "mpv",
                   pull_number: pr_number,


### PR DESCRIPTION
https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
> When you get, [create](https://docs.github.com/rest/pulls/pulls/#create-a-pull-request), or [edit](https://docs.github.com/rest/pulls/pulls#update-a-pull-request) a pull request, GitHub creates a merge commit to test whether the pull request can be automatically merged into the base branch. This test commit is not added to the base branch or the head branch. You can review the status of the test commit using the `mergeable` key. For more information, see "[Checking mergeability of pull requests](https://docs.github.com/rest/guides/getting-started-with-the-git-database-api#checking-mergeability-of-pull-requests)".
>
> The value of the `mergeable` attribute can be `true`, `false`, or `null`. If the value is `null`, then GitHub has started a background job to compute the mergeability. After giving the job time to complete, resubmit the request. When the job finishes, you will see a non-`null` value for the `mergeable` attribute in the response. If `mergeable` is `true`, then `merge_commit_sha` will be the SHA of the test merge commit.