### PR TITLE
ci: enable ThinLTO for LLVM PGO build

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -111,8 +111,8 @@ jobs:
         with:
           bit: "64-v3"
           compiler: "clang"
-          command: "ninja -C $buildroot/build$bit llvm"
-          extra_option: "-DLLVM_ENABLE_PGO=USE -DLLVM_PROFDATA_FILE=$buildroot/llvm.profdata"
+          command: "ninja -C $buildroot/build$bit llvm && rm -rf clang_root/llvm-thinlto || true"
+          extra_option: "-DLLVM_ENABLE_PGO=USE -DLLVM_ENABLE_LTO=Thin -DLLVM_PROFDATA_FILE=$buildroot/llvm.profdata"
 
       - name: Save llvm cache
         uses: actions/cache/save@v4.0.2


### PR DESCRIPTION
ccache will run extra preprocessor (cache miss penalty) on the first run, so enable ccache to ensure that LLVM training covers this, and shaderc is added to the training step in order to reinforce this.

since shaderc has been added to the training step, CLANG_PACKAGES_LTO has also been enabled to train ThinLTO link-time code generation/optimization for LLD.

since we've switched to fuchsia clang, the cost of ThinLTO construction has been greatly reduced, and we don't really need to enable ThinLTO for instrumented LLVM. ref: https://github.com/llvm/llvm-project/issues/59506#issuecomment-1351178416